### PR TITLE
feat: split hook into `useBoxStyles` and `usePseudoBoxStyles`

### DIFF
--- a/src/Box.tsx
+++ b/src/Box.tsx
@@ -2,42 +2,42 @@ import React from 'react'
 import clsx from 'clsx'
 
 import { SafeReactHTMLAttributes } from './types'
-import { UseBoxStylesProps, useBoxStyles } from './useBoxStyles'
+import {
+  useBoxStyles,
+  usePseudoBoxStyles,
+  BoxStylesProps,
+  BoxHoverProps,
+  BoxFocusProps,
+} from './useBoxStyles'
 
 export type BoxProps = {
   component?: React.ElementType
   children?: React.ReactNode
-  className?: string
-  style?: React.CSSProperties
-} & UseBoxStylesProps &
-  SafeReactHTMLAttributes
+  styles?: BoxStylesProps
+  hoverStyles?: BoxHoverProps
+  focusStyles?: BoxFocusProps
+} & SafeReactHTMLAttributes
 
 export const Box = ({
-  component,
+  component = 'div',
   children,
   className,
-  style,
-
   styles,
   hoverStyles,
   focusStyles,
   ...props
 }: BoxProps) => {
-  const resolvedClassNames = useBoxStyles({
-    styles,
-    hoverStyles,
-    focusStyles,
-  })
+  const resolvedClassNames =
+    clsx(
+      useBoxStyles(styles),
+      usePseudoBoxStyles(focusStyles, 'focus'),
+      usePseudoBoxStyles(hoverStyles, 'hover'),
+      className,
+    ) || undefined
 
-  const Tag = component ?? 'div'
-
-  return (
-    <Tag
-      className={clsx(resolvedClassNames, className) || undefined}
-      style={style}
-      {...props}
-    >
-      {children}
-    </Tag>
+  return React.createElement(
+    component,
+    { className: resolvedClassNames, ...props },
+    children,
   )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,12 @@
 export { Box } from './Box'
 export type { BoxProps } from './Box'
 
-export { useBoxStyles } from './useBoxStyles'
-export type { UseBoxStylesProps } from './useBoxStyles'
+export { useBoxStyles, usePseudoBoxStyles } from './useBoxStyles'
+export type {
+  BoxStylesProps as BaseBoxStylesProps,
+  BoxHoverProps as BoxHoverProp,
+  BoxFocusProps as BoxFocusProp,
+} from './useBoxStyles'
 
 export { createCalicoTheme, baseCalicoTheme } from './createCalicoTheme'
 export { mapFontsets } from './mapFontsets'

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,13 +6,7 @@ export type ResponsiveProp<AtomName> =
   | Readonly<[AtomName, AtomName, AtomName]>
   | Readonly<[AtomName, AtomName, AtomName, AtomName]>
 
-type ConflictingHtmlProps =
-  | 'color'
-  | 'style'
-  | 'className'
-  | 'width'
-  | 'height'
-  | 'css'
+type ConflictingHtmlProps = 'color' | 'width' | 'height'
 
 export type SafeReactHTMLAttributes = Omit<
   React.AllHTMLAttributes<'div'>,

--- a/src/useBoxStyles.treat.ts
+++ b/src/useBoxStyles.treat.ts
@@ -2,53 +2,50 @@ import { styleTree, styleMap } from 'treat'
 import * as R from 'fp-ts/es6/Record'
 import { pipe } from 'fp-ts/es6/pipeable'
 
-import {
-  mapToProperty,
-  mapFromOptionalTheme,
-  responsiveStyle,
-  variantResponsiveStyle,
-} from './utils'
+import { styleSingleton, mapToBreakpoints, mapToPseudo } from './utils'
 
 export const styles = styleTree((theme) =>
   pipe(
     theme.rules as Required<typeof theme.rules>,
-    R.mapWithIndex((ruleName, rule) =>
+    R.mapWithIndex((propertyName, atoms) =>
       pipe(
-        rule,
-        mapFromOptionalTheme(mapToProperty(ruleName)),
-        responsiveStyle(theme),
+        atoms as Record<string | number, string | number>,
+        R.map(styleSingleton(propertyName)),
+        mapToBreakpoints(theme),
+        R.map(styleMap),
       ),
     ),
-    R.map(R.map(styleMap)),
   ),
 )
 
-export const hoverStyles = styleTree((theme) =>
+export const hover = styleTree((theme) =>
   pipe(
     theme.rules as Required<typeof theme.rules>,
     R.filterWithIndex((ruleName) => Boolean(theme.variants[ruleName]?.hover)),
-    R.mapWithIndex((ruleName: keyof typeof theme.variants, rule) =>
+    R.mapWithIndex((propertyName: keyof typeof theme.variants, atoms) =>
       pipe(
-        rule,
-        mapFromOptionalTheme(mapToProperty(ruleName)),
-        variantResponsiveStyle(theme)(':hover'),
+        atoms as Record<string | number, string | number>,
+        R.map(styleSingleton(propertyName)),
+        R.map(mapToPseudo(':hover')),
+        mapToBreakpoints(theme),
+        R.map(styleMap),
       ),
     ),
-    R.map(R.map(styleMap)),
   ),
 )
 
-export const focusStyles = styleTree((theme) =>
+export const focus = styleTree((theme) =>
   pipe(
     theme.rules as Required<typeof theme.rules>,
     R.filterWithIndex((ruleName) => Boolean(theme.variants[ruleName]?.focus)),
-    R.mapWithIndex((ruleName: keyof typeof theme.variants, rule) =>
+    R.mapWithIndex((propertyName: keyof typeof theme.variants, atoms) =>
       pipe(
-        rule,
-        mapFromOptionalTheme(mapToProperty(ruleName)),
-        variantResponsiveStyle(theme)(':focus'),
+        atoms as Record<string | number, string | number>,
+        R.map(styleSingleton(propertyName)),
+        R.map(mapToPseudo(':focus')),
+        mapToBreakpoints(theme),
+        R.map(styleMap),
       ),
     ),
-    R.map(R.map(styleMap)),
   ),
 )

--- a/src/useBoxStyles.ts
+++ b/src/useBoxStyles.ts
@@ -5,18 +5,18 @@ import { useStyles } from 'react-treat'
 import { resolveResponsiveProp } from './utils'
 import { ResponsiveProp } from './types'
 
-import * as treatStyleRefs from './useBoxStyles.treat'
+import * as styleRefs from './useBoxStyles.treat'
 
 type NotUndefOrNever<T extends {}> = Pick<
   T,
   { [K in keyof T]: T[K] extends undefined | never ? never : K }[keyof T]
 >
 
-type BaseBoxStylesProps = {
+export type BoxStylesProps = {
   [K in keyof Theme['rules']]?: ResponsiveProp<keyof Theme['rules'][K]>
 }
 
-type BoxHoverProp = NotUndefOrNever<
+export type BoxHoverProps = NotUndefOrNever<
   {
     [K in keyof Theme['variants']]?: NonNullable<
       Theme['variants'][K]
@@ -26,7 +26,7 @@ type BoxHoverProp = NotUndefOrNever<
   }
 >
 
-type BoxFocusProp = NotUndefOrNever<
+export type BoxFocusProps = NotUndefOrNever<
   {
     [K in keyof Theme['variants']]?: NonNullable<
       Theme['variants'][K]
@@ -36,10 +36,7 @@ type BoxFocusProp = NotUndefOrNever<
   }
 >
 
-const resolveClassNames = (
-  props: BaseBoxStylesProps | undefined,
-  styles: any,
-) => {
+const resolveClassNames = (props: BoxStylesProps | undefined, styles: any) => {
   if (props === undefined) return
 
   let resolvedClassNames: (string | undefined)[] = []
@@ -56,22 +53,25 @@ const resolveClassNames = (
   return resolvedClassNames
 }
 
-export type UseBoxStylesProps = {
-  hoverStyles?: BoxHoverProp
-  focusStyles?: BoxFocusProp
-  styles?: BaseBoxStylesProps
+export function useBoxStyles(styles: BoxStylesProps | undefined): string {
+  const boxStyles = useStyles(styleRefs)
+
+  return clsx(resolveClassNames(styles, boxStyles.styles))
 }
 
-export const useBoxStyles = ({
-  hoverStyles,
-  focusStyles,
-  styles,
-}: UseBoxStylesProps) => {
-  const styleRefs = useStyles(treatStyleRefs)
+export function usePseudoBoxStyles(
+  styles: BoxFocusProps | undefined,
+  pseudo: 'focus',
+): string
+export function usePseudoBoxStyles(
+  styles: BoxHoverProps | undefined,
+  pseudo: 'hover',
+): string
+export function usePseudoBoxStyles(
+  styles: BoxHoverProps | BoxFocusProps | undefined,
+  pseudo: 'focus' | 'hover',
+): string {
+  const boxStyles = useStyles(styleRefs)
 
-  return clsx(
-    resolveClassNames(styles, styleRefs.styles),
-    resolveClassNames(hoverStyles, styleRefs.hoverStyles),
-    resolveClassNames(focusStyles, styleRefs.focusStyles),
-  )
+  return clsx(resolveClassNames(styles, boxStyles[pseudo]))
 }

--- a/test/mapFontsets.test.ts
+++ b/test/mapFontsets.test.ts
@@ -17,19 +17,13 @@ test('mapFontsets', () => {
   ).toMatchInlineSnapshot(`
     Object {
       "sans1": Object {
+        ":before": Object {
+          "content": "''",
+          "display": "block",
+          "height": 0,
+          "marginTop": "-0.33999999999999986rem",
+        },
         "@media": Object {
-          "screen and (min-width: 0rem)": Object {
-            ":before": Object {
-              "content": "''",
-              "display": "block",
-              "height": 0,
-              "marginTop": "-0.33999999999999986rem",
-            },
-            "fontSize": "1rem",
-            "lineHeight": "0.9624999999999999rem",
-            "paddingTop": 1,
-            "transform": "translateY(0.10124999999999995em)",
-          },
           "screen and (min-width: 48rem)": Object {
             ":before": Object {
               "content": "''",
@@ -43,6 +37,10 @@ test('mapFontsets', () => {
             "transform": "translateY(0.10125em)",
           },
         },
+        "fontSize": "1rem",
+        "lineHeight": "0.9624999999999999rem",
+        "paddingTop": 1,
+        "transform": "translateY(0.10124999999999995em)",
       },
     }
   `)


### PR DESCRIPTION
Splits hook usage into two hooks:

- `useBoxStyles`: Non-pseudo styles
- `usePsuedoBoxStyles`: Pseudo styles

Also fixes the following:

- Remove the base `0rem` media query from responsive styles
- Refactor the existing Treat implementation and affected utils