### PR TITLE
feat: support polymorphic components via react-polymorphic-box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 node_modules
 .vscode
+shell.nix

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   ],
   "dependencies": {
     "clsx": "^1.1.1",
-    "fp-ts": "^2.6.7"
+    "fp-ts": "^2.6.7",
+    "react-polymorphic-box": "^2.0.7"
   },
   "devDependencies": {
     "@babel/core": "^7.10.4",

--- a/src/Box.tsx
+++ b/src/Box.tsx
@@ -76,10 +76,12 @@ export const Box = React.forwardRef(
       ) || undefined
 
     // TODO: Remove in 1.0 release.
-    if (component && !didWarnAboutComponentPropMigration)
+    if (component && !didWarnAboutComponentPropMigration) {
       console.warn(
         'A Calico <Box> component was found using the `component` prop. The `component` prop is deprecated and has been replaced by the `as` prop and will be removed in v1.0. You should be able to rename `component` to `as` without any other changes.',
       )
+      didWarnAboutComponentPropMigration = true
+    }
 
     return (
       <PolymorphicBox

--- a/src/Box.tsx
+++ b/src/Box.tsx
@@ -76,7 +76,11 @@ export const Box = React.forwardRef(
       ) || undefined
 
     // TODO: Remove in 1.0 release.
-    if (component && !didWarnAboutComponentPropMigration) {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      component &&
+      !didWarnAboutComponentPropMigration
+    ) {
       console.warn(
         'A Calico <Box> component was found using the `component` prop. The `component` prop is deprecated and has been replaced by the `as` prop and will be removed in v1.0. You should be able to rename `component` to `as` without any other changes.',
       )

--- a/src/Box.tsx
+++ b/src/Box.tsx
@@ -1,4 +1,8 @@
-import React from 'react'
+import * as React from 'react'
+import {
+  Box as PolymorphicBox,
+  PolymorphicComponentProps,
+} from 'react-polymorphic-box'
 import clsx from 'clsx'
 
 import { SafeReactHTMLAttributes } from './types'
@@ -10,16 +14,13 @@ import {
   BoxFocusProps,
 } from './useBoxStyles'
 
+const defaultElement = 'div'
+
 /**
  * A `<Box />` accepts all standard HTML props in addition to
  * some additional props for styling.
  */
-export type BoxProps = {
-  /** The HTML element to render the `Box` as. */
-  component?: React.ElementType
-
-  children?: React.ReactNode
-
+type CalicoBoxProps = {
   /** The atomic styles to apply to this element. */
   styles?: BoxStylesProps
 
@@ -28,11 +29,15 @@ export type BoxProps = {
 
   /** The atomic hover styles to apply to this element. */
   focusStyles?: BoxFocusProps
-} & SafeReactHTMLAttributes
+} & Omit<SafeReactHTMLAttributes, 'as'>
+
+export type BoxProps<
+  E extends React.ElementType = typeof defaultElement
+> = PolymorphicComponentProps<E, CalicoBoxProps>
 
 /**
  * The basic building block of `calico`. By default, it renders a `<div />` element,
- * but this can be overridden via the `component` prop.
+ * but this can be overridden via the `as` prop.
  *
  * @param props
  *
@@ -40,17 +45,9 @@ export type BoxProps = {
  * const Example = () => <Box styles={{ color: 'red' }} />
  */
 export const Box = React.forwardRef(
-  (
-    {
-      component = 'div',
-      children,
-      className,
-      styles,
-      hoverStyles,
-      focusStyles,
-      ...props
-    }: BoxProps,
-    ref,
+  <E extends React.ElementType = typeof defaultElement>(
+    { styles, hoverStyles, focusStyles, className, ...restProps }: BoxProps<E>,
+    innerRef: typeof restProps.ref,
   ) => {
     const resolvedClassNames =
       clsx(
@@ -60,12 +57,17 @@ export const Box = React.forwardRef(
         className,
       ) || undefined
 
-    return React.createElement(
-      component,
-      { className: resolvedClassNames, ref, ...props },
-      children,
+    return (
+      <PolymorphicBox
+        as={defaultElement}
+        className={resolvedClassNames}
+        {...restProps}
+        ref={innerRef}
+      />
     )
   },
-)
+) as (<E extends React.ElementType = typeof defaultElement>(
+  props: BoxProps<E>,
+) => JSX.Element) & { displayName: string }
 
 Box.displayName = 'Box'

--- a/src/Box.tsx
+++ b/src/Box.tsx
@@ -21,6 +21,14 @@ const defaultElement = 'div'
  * some additional props for styling.
  */
 type CalicoBoxProps = {
+  // TODO: Remove in 1.0 release.
+  /**
+   * The HTML element to render the `Box` as.
+   *
+   * @deprecated Use the `as` prop instead.
+   */
+  component?: React.ElementType
+
   /** The atomic styles to apply to this element. */
   styles?: BoxStylesProps
 
@@ -35,6 +43,9 @@ export type BoxProps<
   E extends React.ElementType = typeof defaultElement
 > = PolymorphicComponentProps<E, CalicoBoxProps>
 
+// TODO: Remove in 1.0 release.
+let didWarnAboutComponentPropMigration = false
+
 /**
  * The basic building block of `calico`. By default, it renders a `<div />` element,
  * but this can be overridden via the `as` prop.
@@ -46,7 +57,14 @@ export type BoxProps<
  */
 export const Box = React.forwardRef(
   <E extends React.ElementType = typeof defaultElement>(
-    { styles, hoverStyles, focusStyles, className, ...restProps }: BoxProps<E>,
+    {
+      styles,
+      hoverStyles,
+      focusStyles,
+      className,
+      component,
+      ...restProps
+    }: BoxProps<E>,
     innerRef: typeof restProps.ref,
   ) => {
     const resolvedClassNames =
@@ -57,9 +75,15 @@ export const Box = React.forwardRef(
         className,
       ) || undefined
 
+    // TODO: Remove in 1.0 release.
+    if (component && !didWarnAboutComponentPropMigration)
+      console.warn(
+        'A Calico <Box> component was found using the `component` prop. The `component` prop is deprecated and has been replaced by the `as` prop and will be removed in v1.0. You should be able to rename `component` to `as` without any other changes.',
+      )
+
     return (
       <PolymorphicBox
-        as={defaultElement}
+        as={component || defaultElement}
         className={resolvedClassNames}
         {...restProps}
         ref={innerRef}

--- a/test/Box.test.ts
+++ b/test/Box.test.ts
@@ -253,6 +253,15 @@ test('resposnive styles', async () => {
   `)
 })
 
+test('polymorphic component', async () => {
+  const dataFooVal = await page.evaluate(() => {
+    const el = document.querySelector('#polymorphic')
+    return el?.getAttribute?.('data-foo')
+  })
+
+  expect(dataFooVal).toBe('bar')
+})
+
 afterAll(() => {
   server.close()
 })

--- a/test/Box.test.ts
+++ b/test/Box.test.ts
@@ -4,7 +4,6 @@ import { startFixture, FixtureServer } from './utils/startFixture'
 import { getStyles } from './utils/getStyles'
 
 let server: FixtureServer
-let consoleMessages = [] as { type: string; text: string }[]
 
 //@ts-ignore
 // This is here due to type conflicts between
@@ -15,10 +14,6 @@ beforeAll(async () => {
   server = await startFixture({
     entry: require.resolve('./fixtures/App.tsx'),
   })
-  consoleMessages = []
-  page.on('console', (message) =>
-    consoleMessages.push({ type: message.type(), text: message.text() }),
-  )
   await page.goto(server.url)
 })
 
@@ -274,10 +269,6 @@ test('polymorphic component with component prop', async () => {
   })
 
   expect(dataFooVal).toBe('bar')
-  expect(consoleMessages).toContainEqual({
-    type: 'warning',
-    text: expect.stringMatching(/`component` prop.*deprecated/),
-  })
 })
 
 afterAll(() => {

--- a/test/fixtures/App.tsx
+++ b/test/fixtures/App.tsx
@@ -136,6 +136,7 @@ const App = () => (
       }}
     />
     <Box id="polymorphic" as={CompWithDefaultProps} />
+    <Box id="polymorphic-component-prop" component={CompWithDefaultProps} />
   </>
 )
 

--- a/test/fixtures/App.tsx
+++ b/test/fixtures/App.tsx
@@ -2,8 +2,12 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { TreatProvider } from 'react-treat'
 
-import { Box } from '../../src/Box'
+import { Box, BoxProps } from '../../src/Box'
 import { theme } from './theme.treat'
+
+const CompWithDefaultProps = (props: BoxProps) => (
+  <Box data-foo="bar" {...props} />
+)
 
 const App = () => (
   <>
@@ -131,6 +135,7 @@ const App = () => (
         color: ['black', null, 'white'],
       }}
     />
+    <Box id="polymorphic" as={CompWithDefaultProps} />
   </>
 )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7948,6 +7948,11 @@ react-is@^16.12.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-polymorphic-box@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/react-polymorphic-box/-/react-polymorphic-box-2.0.7.tgz#96c629d3d95c9c7522f375ed833fcb41616f583b"
+  integrity sha512-JDbU9gKwliBMbP9XiqnLqnc314e27eS3B+dlvDRTzDrGiL3IzMsPzJJ9/0KPlruQYJeF2BSbehnHjdr01IXXfQ==
+
 react-treat@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/react-treat/-/react-treat-1.4.1.tgz#682be7bf63ca9f9b9f45251b7bea253227044b4f"


### PR DESCRIPTION
Integrates `react-polymorphic-box` to support polymorphic components.

Calico already supported changing the rendered component using the `component` prop, but was limited to HTML element types only. Utilizing `react-polymorphic-box`, we can support any React element (HTML elements and React components) with prop type-safety.

**Deprecation notice**: The `component` prop is deprecated and should be replaced by the `as` prop. Renaming the prop is all that is necessary to migrate. `react-polymorphic-box` uses the `as` prop to provide the element to render. This is based off the styled-components convention and is a more prevalent convention than the `component` prop. For reference, the `component` prop name was taken from SEEK's Braid Design System.
